### PR TITLE
New config paths for OpenGL settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+# Created by .ignore support plugin (hsz.mobi)

--- a/LibreOffice.admx
+++ b/LibreOffice.admx
@@ -12,6 +12,7 @@
       <definition name="SupportedLO4_2" displayName="$(string.SupportedLO4_2)" />
       <definition name="SupportedLO4_3" displayName="$(string.SupportedLO4_3)" />
       <definition name="SupportedLO4_4" displayName="$(string.SupportedLO4_4)" />
+      <definition name="SupportedLO5_0" displayName="$(string.SupportedLO5_0)" />
     </definitions>
   </supportedOn>
   <categories>

--- a/LibreOffice.admx
+++ b/LibreOffice.admx
@@ -525,6 +525,51 @@
       </elements>
     </policy>
     <!--# GENERAL #-->
+    <!--View-->
+    <policy name="UseOpenGL" class="Machine" displayName="$(string.UseOpenGL)" explainText="$(string.UseOpenGL)" presentation="$(presentation.UseOpenGL)" key="Software\policies\LibreOffice\org.openoffice.Office.Common\VCL\UseOpenGL">
+      <parentCategory ref="CAT_LibreOfficeGeneral" />
+      <supportedOn ref="SupportedLO5_0" />
+      <elements>
+        <boolean id="UseOpenGLValue" valueName="Value">
+          <trueValue>
+            <string>true</string>
+          </trueValue>
+          <falseValue>
+            <string>false</string>
+          </falseValue>
+        </boolean>
+        <boolean id="UseOpenGLEnforce" valueName="Final">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+    <policy name="ForceOpenGL" class="Machine" displayName="$(string.ForceOpenGL)" explainText="$(string.ForceOpenGL)" presentation="$(presentation.ForceOpenGL)" key="Software\policies\LibreOffice\org.openoffice.Office.Common\VCL\ForceOpenGL">
+      <parentCategory ref="CAT_LibreOfficeGeneral" />
+      <supportedOn ref="SupportedLO5_0" />
+      <elements>
+        <boolean id="ForceOpenGLValue" valueName="Value">
+          <trueValue>
+            <string>true</string>
+          </trueValue>
+          <falseValue>
+            <string>false</string>
+          </falseValue>
+        </boolean>
+        <boolean id="ForceOpenGLEnforce" valueName="Final">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
     <!--Help-->
     <policy name="CommonHelpTip" class="Machine" displayName="$(string.CommonHelpTip)" explainText="$(string.CommonHelpTipHelp)" presentation="$(presentation.CommonHelpTip)" key="Software\policies\LibreOffice\org.openoffice.Office.Common\Help\Tip">
       <parentCategory ref="CAT_LibreOfficeGeneral" />

--- a/en-US/LibreOffice.adml
+++ b/en-US/LibreOffice.adml
@@ -9,7 +9,7 @@
       <string id="SupportedLO4_2">At least LibreOffice 4.2</string>
       <string id="SupportedLO4_3">At least LibreOffice 4.3</string>
       <string id="SupportedLO4_4">At least LibreOffice 4.4</string>
-      <string id="SupportedLO5_01">At least LibreOffice 5.0</string>
+      <string id="SupportedLO5_0">At least LibreOffice 5.0</string>
       <!--#### CATEGORIES ####-->
       <!--## LIBREOFFICE ##-->
       <string id="CAT_LibreOfficeRoot">LibreOffice</string>
@@ -125,6 +125,9 @@
       <string id="UserProfileDatao">Company Name</string>
       <string id="UserProfileDataoHelp">Enter the Company Name.</string>
       <!--# GENERAL #-->
+      <!--View-->
+      <string id="UseOpenGL">Use full OpenGL rendering </string>
+      <string id="ForceOpenGL">Force full OpenGL rendering, even if blacklisted</string>
       <!--Help-->
       <string id="CommonHelpTip">Show Tips</string>
       <string id="CommonHelpTipHelp">Set whether LibreOffice shows tips</string>
@@ -195,7 +198,7 @@ file:///S:/Important%20Files file:///S:/Documents
  - Replace back slashes with forward slashes
  - Replace spaces with '%20'.
  - Separate multiple paths with a space.
- 
+
  Example:
  file:///S:/Important%20Files file:///S:/Documents
 	  </string>
@@ -389,6 +392,15 @@ file:///S:/Important%20Files file:///S:/Documents
         <checkBox refId="UserProfileDataoEnforce">Enforce</checkBox>
       </presentation>
       <!--# GENERAL #-->
+      <!--View-->
+      <presentation id="UseOpenGL">
+        <checkBox refId="UseOpenGLValue">Use OpenGL</checkBox>
+        <checkBox refId="UseOpenGLEnforce">Enforce</checkBox>
+      </presentation>
+      <presentation id="ForceOpenGL">
+        <checkBox refId="ForceOpenGLValue">Force OpenGL</checkBox>
+        <checkBox refId="ForceOpenGLEnforce">Enforce</checkBox>
+      </presentation>
       <!--Help-->
       <presentation id="CommonHelpTip">
         <checkBox refId="CommonHelpTipValue">Show Tips</checkBox>

--- a/en-US/LibreOffice.adml
+++ b/en-US/LibreOffice.adml
@@ -9,6 +9,7 @@
       <string id="SupportedLO4_2">At least LibreOffice 4.2</string>
       <string id="SupportedLO4_3">At least LibreOffice 4.3</string>
       <string id="SupportedLO4_4">At least LibreOffice 4.4</string>
+      <string id="SupportedLO5_01">At least LibreOffice 5.0</string>
       <!--#### CATEGORIES ####-->
       <!--## LIBREOFFICE ##-->
       <string id="CAT_LibreOfficeRoot">LibreOffice</string>


### PR DESCRIPTION
Hi,
I've added two items to control OpenGL settings in:
- `Software\policies\LibreOffice\org.openoffice.Office.Common\VCL\UseOpenGL`
- `Software\policies\LibreOffice\org.openoffice.Office.Common\VCL\ForceOpenGL`

Kind regards
Filip Paczyński
